### PR TITLE
Refresh the style.css comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ Check out the [style guide][guide] to see what it looks like.
 
 Some differences from [style.css][style]:
 
-- CSS Variables
-- Dark Mode
-- Remove some old browser support
-- Use post-css build pipeline
-- Minor stylistic differences
+- Custom properties for typography, semantic colors, control borders, and
+  raised-surface depth
+- Browser-controlled light and dark palettes, a dedicated print palette, and
+  optional named color themes
+- Bounded fluid type instead of an indefinitely viewport-scaled base font size
+- Modern keyboard-focus treatment, responsive overflow, and consistent form
+  spacing
+- A modern browser baseline with native CSS nesting and fewer legacy
+  normalization rules
+- A CSS-only package with optional layout, top-bar, named-theme, and
+  Highlight.js sidecars
 - [CHANGELOG.md](./CHANGELOG.md)
 - [Migrating from v10 to v11](./MIGRATION.md)
 


### PR DESCRIPTION
The README's comparison with `style.css` had become stale. In particular, it still described a PostCSS build as a mine.css difference even though current `style.css` also builds through Sass, PostCSS, and Autoprefixer.

This replaces the historical shorthand with concrete, consumer-visible v11 differences: customizable semantic tokens, browser-controlled palettes and print treatment, bounded fluid type, modern focus and layout behavior, the native-nesting browser baseline, and the optional CSS sidecars.

The comparison was checked against the current upstream `style.css` source and package metadata.

### Validation

- `npm test`
- 10 Node tests and 10 Playwright tests
- README static-site render
